### PR TITLE
Make shared crate evm-tracing-events compatible with old tracing runtimes

### DIFF
--- a/tracing/1000/runtime/moonbase/Cargo.toml
+++ b/tracing/1000/runtime/moonbase/Cargo.toml
@@ -44,7 +44,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1000", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1000", default-features = false }

--- a/tracing/1000/runtime/moonriver/Cargo.toml
+++ b/tracing/1000/runtime/moonriver/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1000", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1000", default-features = false }

--- a/tracing/1001/runtime/moonbase/Cargo.toml
+++ b/tracing/1001/runtime/moonbase/Cargo.toml
@@ -44,7 +44,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1001", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1001", default-features = false }

--- a/tracing/1001/runtime/moonbeam/Cargo.toml
+++ b/tracing/1001/runtime/moonbeam/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1001", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"]  }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1001", default-features = false }

--- a/tracing/1001/runtime/moonriver/Cargo.toml
+++ b/tracing/1001/runtime/moonriver/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1001", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1001", default-features = false }

--- a/tracing/1002/runtime/moonbase/Cargo.toml
+++ b/tracing/1002/runtime/moonbase/Cargo.toml
@@ -44,7 +44,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1002", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = [ "transaction_v0" ] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1002", default-features = false }

--- a/tracing/1002/runtime/moonbeam/Cargo.toml
+++ b/tracing/1002/runtime/moonbeam/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1002", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = [ "transaction_v0" ] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1002", default-features = false }

--- a/tracing/1002/runtime/moonriver/Cargo.toml
+++ b/tracing/1002/runtime/moonriver/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1002", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = [ "transaction_v0" ] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1002", default-features = false }

--- a/tracing/1100/runtime/moonbase/Cargo.toml
+++ b/tracing/1100/runtime/moonbase/Cargo.toml
@@ -44,7 +44,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1100", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1100", default-features = false }

--- a/tracing/1100/runtime/moonbeam/Cargo.toml
+++ b/tracing/1100/runtime/moonbeam/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1100", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1100", default-features = false }

--- a/tracing/1100/runtime/moonriver/Cargo.toml
+++ b/tracing/1100/runtime/moonriver/Cargo.toml
@@ -43,7 +43,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1100", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1100", default-features = false }

--- a/tracing/1101/runtime/moonbase/Cargo.toml
+++ b/tracing/1101/runtime/moonbase/Cargo.toml
@@ -44,7 +44,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1101", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1101", default-features = false }

--- a/tracing/1101/runtime/moonbeam/Cargo.toml
+++ b/tracing/1101/runtime/moonbeam/Cargo.toml
@@ -34,7 +34,7 @@ crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam",
 parachain-staking-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1101", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1101", default-features = false }

--- a/tracing/1101/runtime/moonriver/Cargo.toml
+++ b/tracing/1101/runtime/moonriver/Cargo.toml
@@ -43,7 +43,7 @@ xcm-transactor-precompiles = { git = "https://github.com/purestake/moonbeam", re
 xtokens-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1101", default-features = false }
 
 # Moonbeam tracing
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-1101", default-features = false }

--- a/tracing/155/runtime/moonbase/Cargo.toml
+++ b/tracing/155/runtime/moonbase/Cargo.toml
@@ -76,7 +76,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c25242f8" }
 

--- a/tracing/155/runtime/moonriver/Cargo.toml
+++ b/tracing/155/runtime/moonriver/Cargo.toml
@@ -75,7 +75,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c25242f8" }
 

--- a/tracing/159/runtime/moonbase/Cargo.toml
+++ b/tracing/159/runtime/moonbase/Cargo.toml
@@ -75,7 +75,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false, branch = "main" }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-159", default-features = false }
 

--- a/tracing/159/runtime/moonriver/Cargo.toml
+++ b/tracing/159/runtime/moonriver/Cargo.toml
@@ -74,7 +74,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false, branch = "main" }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-159", default-features = false }
 

--- a/tracing/200/runtime/moonbase/Cargo.toml
+++ b/tracing/200/runtime/moonbase/Cargo.toml
@@ -76,7 +76,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-200", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-200", default-features = false }
 

--- a/tracing/200/runtime/moonriver/Cargo.toml
+++ b/tracing/200/runtime/moonriver/Cargo.toml
@@ -74,7 +74,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-200", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-200", default-features = false }
 

--- a/tracing/400/runtime/moonbase/Cargo.toml
+++ b/tracing/400/runtime/moonbase/Cargo.toml
@@ -78,7 +78,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-400", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-400", default-features = false }
 

--- a/tracing/400/runtime/moonriver/Cargo.toml
+++ b/tracing/400/runtime/moonriver/Cargo.toml
@@ -76,7 +76,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-400", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-400", default-features = false }
 

--- a/tracing/47/runtime/moonbase/Cargo.toml
+++ b/tracing/47/runtime/moonbase/Cargo.toml
@@ -66,7 +66,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "e45bda9e" }
 

--- a/tracing/49/runtime/moonriver/Cargo.toml
+++ b/tracing/49/runtime/moonriver/Cargo.toml
@@ -66,7 +66,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "e45bda9e" }
 

--- a/tracing/501/runtime/moonbase/Cargo.toml
+++ b/tracing/501/runtime/moonbase/Cargo.toml
@@ -78,7 +78,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-501", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-501", default-features = false }
 

--- a/tracing/501/runtime/moonriver/Cargo.toml
+++ b/tracing/501/runtime/moonriver/Cargo.toml
@@ -76,7 +76,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-501", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-501", default-features = false }
 

--- a/tracing/52/runtime/moonbase/Cargo.toml
+++ b/tracing/52/runtime/moonbase/Cargo.toml
@@ -76,7 +76,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false}
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c63c9a15" }
 

--- a/tracing/53/runtime/moonriver/Cargo.toml
+++ b/tracing/53/runtime/moonriver/Cargo.toml
@@ -69,7 +69,7 @@ pallet-treasury = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false}
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c63c9a15" }
 

--- a/tracing/600/runtime/moonbase/Cargo.toml
+++ b/tracing/600/runtime/moonbase/Cargo.toml
@@ -78,7 +78,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-600", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-600", default-features = false }
 

--- a/tracing/600/runtime/moonriver/Cargo.toml
+++ b/tracing/600/runtime/moonriver/Cargo.toml
@@ -76,7 +76,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-600", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-600", default-features = false }
 

--- a/tracing/700/runtime/moonbase/Cargo.toml
+++ b/tracing/700/runtime/moonbase/Cargo.toml
@@ -85,7 +85,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-700", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = [ "transaction_v0" ] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-700", default-features = false }
 

--- a/tracing/700/runtime/moonriver/Cargo.toml
+++ b/tracing/700/runtime/moonriver/Cargo.toml
@@ -76,7 +76,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-700", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = [ "transaction_v0" ] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-700", default-features = false }
 

--- a/tracing/701/runtime/moonbase/Cargo.toml
+++ b/tracing/701/runtime/moonbase/Cargo.toml
@@ -85,7 +85,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-701", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-701", default-features = false }
 

--- a/tracing/701/runtime/moonriver/Cargo.toml
+++ b/tracing/701/runtime/moonriver/Cargo.toml
@@ -76,7 +76,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-701", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-701", default-features = false }
 

--- a/tracing/800/runtime/moonbase/Cargo.toml
+++ b/tracing/800/runtime/moonbase/Cargo.toml
@@ -88,7 +88,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-800", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-800", default-features = false }
 

--- a/tracing/800/runtime/moonriver/Cargo.toml
+++ b/tracing/800/runtime/moonriver/Cargo.toml
@@ -77,7 +77,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-800", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-800", default-features = false }
 

--- a/tracing/900/runtime/moonbase/Cargo.toml
+++ b/tracing/900/runtime/moonbase/Cargo.toml
@@ -94,7 +94,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }
 moonbeam-relay-encoder = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }

--- a/tracing/900/runtime/moonbeam/Cargo.toml
+++ b/tracing/900/runtime/moonbeam/Cargo.toml
@@ -82,7 +82,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }
 

--- a/tracing/900/runtime/moonriver/Cargo.toml
+++ b/tracing/900/runtime/moonriver/Cargo.toml
@@ -81,7 +81,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-900", default-features = false }
 

--- a/tracing/901/runtime/moonbase/Cargo.toml
+++ b/tracing/901/runtime/moonbase/Cargo.toml
@@ -94,7 +94,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-901", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-901", default-features = false }
 moonbeam-relay-encoder = { git = "https://github.com/purestake/moonbeam", rev = "runtime-901", default-features = false }

--- a/tracing/902/runtime/moonbase/Cargo.toml
+++ b/tracing/902/runtime/moonbase/Cargo.toml
@@ -94,7 +94,7 @@ pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewar
 crowdloan-rewards-precompiles = { git = "https://github.com/purestake/moonbeam", rev = "runtime-902", default-features = false }
 
 moonbeam-evm-tracer = { path = "../../../shared/runtime/evm_tracer", optional = true, default-features = false }
-evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+evm-tracing-events = { path = "../../../shared/primitives/rpc/evm-tracing-events", optional = true, default-features = false, features = ["before_1200"] }
 moonbeam-rpc-primitives-debug = { path = "../../../shared/primitives/rpc/debug", default-features = false, features = ["transaction_v0"] }
 moonbeam-rpc-primitives-txpool = { git = "https://github.com/purestake/moonbeam", rev = "runtime-902", default-features = false }
 moonbeam-relay-encoder = { git = "https://github.com/purestake/moonbeam", rev = "runtime-902", default-features = false }

--- a/tracing/shared/primitives/rpc/evm-tracing-events/Cargo.toml
+++ b/tracing/shared/primitives/rpc/evm-tracing-events/Cargo.toml
@@ -27,6 +27,10 @@ evm-gasometer = { version = "*", default-features = false }
 
 [features]
 default = ["std"]
+
+# Adapt the source code to compile old tracing runtimes (chain spec < 1200)
+before_1200 = []
+
 evm-tracing = ["evm/tracing", "evm-runtime/tracing", "evm-gasometer/tracing"]
 std = [
 	"codec/std",

--- a/tracing/shared/primitives/rpc/evm-tracing-events/src/gasometer.rs
+++ b/tracing/shared/primitives/rpc/evm-tracing-events/src/gasometer.rs
@@ -30,17 +30,49 @@ impl Snapshot {
 	}
 }
 
-impl From<evm_gasometer::Snapshot> for Snapshot {
-	fn from(i: evm_gasometer::Snapshot) -> Self {
-		Self {
-			gas_limit: i.gas_limit,
-			memory_gas: i.memory_gas,
-			used_gas: i.used_gas,
-			refunded_gas: i.refunded_gas,
-		}
+#[cfg(feature = "before_1200")]
+fn convert_snapshot(snapshot: evm_gasometer::Snapshot) -> Snapshot {
+	Snapshot {
+		gas_limit: snapshot.gas_limit,
+		memory_gas: snapshot.memory_gas,
+		used_gas: snapshot.used_gas,
+		refunded_gas: snapshot.refunded_gas,
 	}
 }
 
+#[cfg(not(feature = "before_1200"))]
+fn convert_snapshot(snapshot_opt: Option<evm_gasometer::Snapshot>) -> Option<Snapshot> {
+	snapshot_opt.map(Into::into)
+}
+
+#[cfg(feature = "before_1200")]
+#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
+pub enum GasometerEvent {
+	RecordCost {
+		cost: u64,
+		snapshot: Snapshot,
+	},
+	RecordRefund {
+		refund: i64,
+		snapshot: Snapshot,
+	},
+	RecordStipend {
+		stipend: u64,
+		snapshot: Snapshot,
+	},
+	RecordDynamicCost {
+		gas_cost: u64,
+		memory_gas: u64,
+		gas_refund: i64,
+		snapshot: Snapshot,
+	},
+	RecordTransaction {
+		cost: u64,
+		snapshot: Snapshot,
+	},
+}
+
+#[cfg(not(feature = "before_1200"))]
 #[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
 pub enum GasometerEvent {
 	RecordCost {
@@ -73,18 +105,18 @@ impl From<evm_gasometer::tracing::Event> for GasometerEvent {
 		match i {
 			evm_gasometer::tracing::Event::RecordCost { cost, snapshot } => Self::RecordCost {
 				cost,
-				snapshot: snapshot.map(Into::into),
+				snapshot: convert_snapshot(snapshot),
 			},
 			evm_gasometer::tracing::Event::RecordRefund { refund, snapshot } => {
 				Self::RecordRefund {
 					refund,
-					snapshot: snapshot.map(Into::into),
+					snapshot: convert_snapshot(snapshot),
 				}
 			}
 			evm_gasometer::tracing::Event::RecordStipend { stipend, snapshot } => {
 				Self::RecordStipend {
 					stipend,
-					snapshot: snapshot.map(Into::into),
+					snapshot: convert_snapshot(snapshot),
 				}
 			}
 			evm_gasometer::tracing::Event::RecordDynamicCost {
@@ -96,12 +128,12 @@ impl From<evm_gasometer::tracing::Event> for GasometerEvent {
 				gas_cost,
 				memory_gas,
 				gas_refund,
-				snapshot: snapshot.map(Into::into),
+				snapshot: convert_snapshot(snapshot),
 			},
 			evm_gasometer::tracing::Event::RecordTransaction { cost, snapshot } => {
 				Self::RecordTransaction {
 					cost,
-					snapshot: snapshot.map(Into::into),
+					snapshot: convert_snapshot(snapshot),
 				}
 			}
 		}

--- a/tracing/shared/primitives/rpc/evm-tracing-events/src/gasometer.rs
+++ b/tracing/shared/primitives/rpc/evm-tracing-events/src/gasometer.rs
@@ -16,7 +16,7 @@
 
 use codec::{Decode, Encode};
 
-#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct Snapshot {
 	pub gas_limit: u64,
 	pub memory_gas: u64,
@@ -41,11 +41,19 @@ fn convert_snapshot(snapshot: evm_gasometer::Snapshot) -> Snapshot {
 }
 
 #[cfg(not(feature = "before_1200"))]
-fn convert_snapshot(snapshot_opt: Option<evm_gasometer::Snapshot>) -> Option<Snapshot> {
-	snapshot_opt.map(Into::into)
+fn convert_snapshot(snapshot_opt: Option<evm_gasometer::Snapshot>) -> Snapshot {
+	if let Some(snapshot) = snapshot_opt {
+		Snapshot {
+			gas_limit: snapshot.gas_limit,
+			memory_gas: snapshot.memory_gas,
+			used_gas: snapshot.used_gas,
+			refunded_gas: snapshot.refunded_gas,
+		}
+	} else {
+		Snapshot::default()
+	}
 }
 
-#[cfg(feature = "before_1200")]
 #[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
 pub enum GasometerEvent {
 	RecordCost {
@@ -69,33 +77,6 @@ pub enum GasometerEvent {
 	RecordTransaction {
 		cost: u64,
 		snapshot: Snapshot,
-	},
-}
-
-#[cfg(not(feature = "before_1200"))]
-#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
-pub enum GasometerEvent {
-	RecordCost {
-		cost: u64,
-		snapshot: Option<Snapshot>,
-	},
-	RecordRefund {
-		refund: i64,
-		snapshot: Option<Snapshot>,
-	},
-	RecordStipend {
-		stipend: u64,
-		snapshot: Option<Snapshot>,
-	},
-	RecordDynamicCost {
-		gas_cost: u64,
-		memory_gas: u64,
-		gas_refund: i64,
-		snapshot: Option<Snapshot>,
-	},
-	RecordTransaction {
-		cost: u64,
-		snapshot: Option<Snapshot>,
 	},
 }
 


### PR DESCRIPTION
The `Snapshot` in the `GasometerEvent` is now optional, but before it was mandatory. This PR adds a compilation feature to handle both cases.