### PR TITLE
Fix path to xcm-transactor pallet

### DIFF
--- a/scripts/import-tracing-runtime.sh
+++ b/scripts/import-tracing-runtime.sh
@@ -28,7 +28,7 @@ PATHS_TO_GIT=(
   precompiles\\/pallet-democracy
   precompiles\\/relay-encoder
   precompiles\\/utils
-  precompiles\\/xcm_transactor
+  precompiles\\/xcm-transactor
   precompiles\\/xtokens
   primitives\\/account\\/
   primitives\\/rpc\\/txpool


### PR DESCRIPTION
Pallet path was changed in https://github.com/PureStake/moonbeam/pull/1580
Path is listed explictely in the import script, thus the CI now fails.